### PR TITLE
close #38 Remove exercise dir in setup of submodules kata

### DIFF
--- a/submodules/setup.sh
+++ b/submodules/setup.sh
@@ -1,3 +1,4 @@
+rm -rf exercise
 mkdir exercise
 
 cd exercise


### PR DESCRIPTION
Accidentally used `deliver` instead of `local-deliver` in the-phlow. Merging manually.