### PR TITLE
Add `log --all` to see difference in commits on branches

### DIFF
--- a/basic-branching/README.md
+++ b/basic-branching/README.md
@@ -18,7 +18,7 @@ Hint: `git checkout` will make you switch from one branch to another.
 1. Switch back to the branch called master
 1. Make a new file called file2.txt
 1. Add and commit that file
-1. Use `git log --oneline --decorate --graph` to see your branch pointing to the new commit, and that the two branches now have different commits on them.
+1. Use `git log --oneline --decorate --graph --all` to see your branch pointing to the new commit, and that the two branches now have different commits on them.
 1. Checkout mybranch
 1. What happened to your working directory? Can you see your file2.txt?
 1. Use `git diff mybranch master` to see the difference between the two branches.


### PR DESCRIPTION
Hello @RandomSort @praqma-training! I'm having lots of fun going through these exercises. 😄 

This PR introduces a small change to the log of the branch activity. When including `--all`, it shows both branches. 

I'm not sure if this is how you intended the activity to go or not, but based on the other context I thought this may be helpful. Please feel free to close if this is incorrect. 

<img width="401" alt="screen shot 2017-05-31 at 10 11 53 am" src="https://cloud.githubusercontent.com/assets/9906718/26639177/b9c43f34-45e9-11e7-9f33-37e34c03686b.png">