### PR TITLE
Recommend nano instead of emacs

### DIFF
--- a/basic-commits/README.md
+++ b/basic-commits/README.md
@@ -40,7 +40,7 @@ You can look at the bottom of this file, if you have not yet done basic git conf
 1. `git config --global user.name "John Doe"`
 1. `git config --global user.email "johndoe@example.com`
 For the vim scared:
-- `git config --global core.editor emacs`
+- `git config --global core.editor nano`
 
 for the windows peeps:
 - `git config --global core.editor notepad`

--- a/configure-git/README.md
+++ b/configure-git/README.md
@@ -6,7 +6,7 @@
 1. `git config --global user.email "johndoe@example.com`
 
 For the vim scared:
-- `git config --global core.editor emacs`
+- `git config --global core.editor nano`
 
 For the windows peeps:
 - `git config --global core.editor notepad`


### PR DESCRIPTION
A) It doesn't help much to replace VI with another editor that people don't know how to exit.
B) nano comes pre-installed on more systems, incl. Git Bash on windows as far as I remember, and on macs.

Yes, I know we lose some of the vi<->emacs war joke, but it makes it more useful for actual participants.